### PR TITLE
Bind method to response to eliminate reading properties from undefined

### DIFF
--- a/src/csrf-protection-middleware.ts
+++ b/src/csrf-protection-middleware.ts
@@ -166,6 +166,8 @@ const csrfFilter = (options: CsrfOptions): RequestHandler => {
 
 const modifiedRender = (res: Response, csrfToken: string) => {
     const originalRender = res.render;
+    originalRender.bind(res);
+
     return (view: string, parametersOrCallback?: object | ((err: Error, html: string) => void), callback?: (err: Error, html: string) => void) => {
         if (typeof parametersOrCallback === "object") {
             return originalRender(


### PR DESCRIPTION
Encounter a:

```text
TypeError: Cannot read properties of undefined (reading 'req')
    at render (/opt/node_modules/express/lib/response.js:995:18)
    at ServerResponse.render (/opt/node_modules/@companieshouse/web-security-node/dist/csrf-protection-middleware.js:89:16)
    at /opt/dist/middleware/createAuthenticationMiddleware.js:37:37
    at Layer.handle [as handle_request] (/opt/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/opt/node_modules/express/lib/router/index.js:323:13)
    at /opt/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/opt/node_modules/express/lib/router/index.js:341:12)
    at next (/opt/node_modules/express/lib/router/index.js:275:10)
    at urlencodedParser (/opt/node_modules/body-parser/lib/types/urlencoded.js:91:7)
    at Layer.handle [as handle_request] (/opt/node_modules/express/lib/router/layer.js:95:5)
```

This is probably because it has lost the connection to response.