### PR TITLE
Add note to README about using EnsureSessionCookiePresentMiddleware as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ token. This implements a
     import { CsrfProtectionMiddleware } from " @companieshouse/web-security-node"
     import {
         SessionStore,
-        SessionMiddleware
+        SessionMiddleware,
+        EnsureSessionCookiePresentMiddleware
     } from '@companieshouse/node-session-handler';
     import express from "express";
     import cookieParser from 'cookie-parser';
@@ -85,6 +86,10 @@ token. This implements a
         sessionCookieName: cookieName
     }
     app.use(createLoggerMiddleware(config.applicationNamespace));
+
+    // Recommended to use the EnsureSessionCookiePresentMiddleware from
+    // `node-session-handler` too - see subsequent note
+    app.use(EnsureSessionCookiePresentMiddleware(cookieConfig))
     
     // It is important that CSRF Protection follows the Sesion and urlencoded
     // Middlewares, maybe put at end of the middleware chain (before
@@ -95,6 +100,13 @@ token. This implements a
     // Add other middlewares and routers
 
     ```
+
+    **Note** the addition of: `EnsureSessionCookiePresentMiddleware` ensures
+    that there is a session cookie in the request before handling the CSRF
+    token. This is important because the CSRF middleware cannot add the CSRF to
+    the session without a session cookie. Without this step any mutable requests
+    following an unauthenticated action will fail. If your application is only
+    authenticated this may not be as applicable.
 
 3. Amend the `Nunjucks` configuration to add the third-party templates from this library:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/node-session-handler": "~5.1.3",
+        "@companieshouse/node-session-handler": "~5.2.0",
         "@companieshouse/structured-logging-node": "~2.0.1",
         "express-async-handler": "^1.2.0",
         "uuid": "^9.0.1"
@@ -498,10 +498,9 @@
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.1.3.tgz",
-      "integrity": "sha512-J2iZlC8tW/HETsphX6e1m3ntoUgfvpKjGMHzR/Oor+e58RVoSKwe0gBYnF10CYfPEInqoKkIgXBOpAvNoQcTew==",
-      "license": "MIT",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.0.tgz",
+      "integrity": "sha512-9ihSGNwx/chZlaHxy5eCKdI6V7I7kNIRhpy9O6ZjE+5jkhfn0qArUdtGnzl7AhknS4OWGGOTiinuV0ZTbO0tjQ==",
       "dependencies": {
         "@companieshouse/structured-logging-node": "^1.0.0",
         "crypto": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/chai": "^4.2.11",
         "@types/express": "^4.17.6",
-        "@types/ioredis": "^4.16.2",
+        "@types/ioredis": "^4.17.4",
         "@types/mocha": "^7.0.2",
         "@types/sinon": "^17.0.1",
         "@types/uuid": "^9.0.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/express": "^4.17.6",
-    "@types/ioredis": "^4.16.2",
+    "@types/ioredis": "^4.17.4",
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^17.0.1",
     "@types/uuid": "^9.0.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage:report": "nyc --reporter=lcov --reporter=text npm run test"
   },
   "dependencies": {
-    "@companieshouse/node-session-handler": "~5.1.3",
+    "@companieshouse/node-session-handler": "~5.2.0",
     "@companieshouse/structured-logging-node": "~2.0.1",
     "express-async-handler": "^1.2.0",
     "uuid": "^9.0.1"


### PR DESCRIPTION
* To mitigate the behaviour observed by registered-email-address-web it is recommended to use the `EnsureSessionCookiePresentMiddleware` middleware provided by `node-session-handler` library
The behaviour namely:

1. The page loads fine, CSRF token is empty
2. Navigate to the next page and there is a CSRF error since it was a post and expected a CSRF token in the session

Expected:
1. Session cookie to be present so could have issued a CSRF token in the session
