### PR TITLE
Add another 'excluded paths' example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,14 @@ token. This implements a
     const excludedPaths = /\/limited-partnerships\/((?!healthcheck).)*/;
     ```
 
-    or, for the /limited-partnerships/healthcheck and /limited-partnerships/start
+    or, for the /limited-partnerships/healthcheck and /limited-partnerships/start end-points
     ```typescript
     const excludedPaths = /\/limited-partnerships/((?!healthcheck|start).)*/;
+    ```
+
+    or, for the /register-an-overseas-entity/healthcheck endpoint (where the base URL changes based on the type of web journey)
+    ```typescript
+    const excludedPaths = /^\/(?!register-an-overseas-entity\/healthcheck).*/;
     ```
 
     then add it to the middleware call

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ token. This implements a
 
     or, for the /limited-partnerships/healthcheck and /limited-partnerships/start end-points
     ```typescript
-    const excludedPaths = /\/limited-partnerships/((?!healthcheck|start).)*/;
+    const excludedPaths = /\/limited-partnerships\/((?!healthcheck|start).)*/;
     ```
 
     or, for the /register-an-overseas-entity/healthcheck endpoint (where the base URL changes based on the type of web journey)


### PR DESCRIPTION
* ROE example added, as it shows a more specific exclusion when base path changes