### PR TITLE
SIV-279 force company re authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@ export interface AuthOptions {
   chsWebUrl: string
   companyNumber?: string
   acspNumber?:string
-  forceCompanyAuthentication?: boolean
-  saveAssociation?: boolean
+  forceAuthCode?: boolean
 }
 
 export const authMiddleware = (options: AuthOptions): RequestHandler => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface AuthOptions {
   chsWebUrl: string
   companyNumber?: string
   acspNumber?:string
+  forceCompanyAuthentication?: boolean
 }
 
 export const authMiddleware = (options: AuthOptions): RequestHandler => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export interface AuthOptions {
   companyNumber?: string
   acspNumber?:string
   forceCompanyAuthentication?: boolean
+  saveAssociation?: boolean
 }
 
 export const authMiddleware = (options: AuthOptions): RequestHandler => (

--- a/src/private-helpers/authMiddlewareHelper.ts
+++ b/src/private-helpers/authMiddlewareHelper.ts
@@ -79,6 +79,11 @@ export const authMiddlewareHelper = (options: AuthOptions, requestScopeAndPermis
       return res.redirect(redirectURI)
     }
 
+    if (options.companyNumber && options.forceCompanyAuthentication) {
+      logger.info(`${appName} - handler: userId=${userId}, forceCompanyAuthentication set to true for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
+      return res.redirect(redirectURI)
+    }
+
     if (options.companyNumber && !isAuthorisedForCompany(options.companyNumber, signInInfo)) {
       logger.info(`${appName} - handler: userId=${userId}, Not Authorised for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
       return res.redirect(redirectURI)

--- a/src/private-helpers/authMiddlewareHelper.ts
+++ b/src/private-helpers/authMiddlewareHelper.ts
@@ -79,8 +79,10 @@ export const authMiddlewareHelper = (options: AuthOptions, requestScopeAndPermis
       return res.redirect(redirectURI)
     }
 
-    if (options.companyNumber && options.forceCompanyAuthentication) {
-      logger.info(`${appName} - handler: userId=${userId}, forceCompanyAuthentication set to true for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
+    if (options.companyNumber && options.forceCompanyAuthentication === true) {
+      const saveAssociation = options.saveAssociation === true;
+      redirectURI = redirectURI.concat(`&force_company_auth=true&save_association=${saveAssociation}`)
+      logger.info(`${appName} - handler: userId=${userId}, forceCompanyAuthentication=true, saveAssociation=${saveAssociation} for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
       return res.redirect(redirectURI)
     }
 

--- a/src/private-helpers/authMiddlewareHelper.ts
+++ b/src/private-helpers/authMiddlewareHelper.ts
@@ -79,10 +79,9 @@ export const authMiddlewareHelper = (options: AuthOptions, requestScopeAndPermis
       return res.redirect(redirectURI)
     }
 
-    if (options.companyNumber && options.forceCompanyAuthentication === true) {
-      const saveAssociation = options.saveAssociation === true;
-      redirectURI = redirectURI.concat(`&force_company_auth=true&save_association=${saveAssociation}`)
-      logger.info(`${appName} - handler: userId=${userId}, forceCompanyAuthentication=true, saveAssociation=${saveAssociation} for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
+    if (options.companyNumber && options.forceAuthCode === true) {
+      redirectURI = redirectURI.concat(`&force-auth-code=true`)
+      logger.info(`${appName} - handler: userId=${userId}, forceAuthCode=true, for ${options.companyNumber}... Redirecting to: ${redirectURI}`)
       return res.redirect(redirectURI)
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -137,4 +137,21 @@ it("Should redirect with force-auth-code=true when forceAuthCode is true when th
     assert(mockNext.notCalled);
   });
 
+it("Should redirect with force-auth-code=true when forceAuthCode is true when the user is not authenticated for company", () => {
+    const expectedAuthReturnUrl = 'accounts/signin?return_to=origin&company_number=12345678&force-auth-code=true'
+    const authedSession = mock(Session)
+    const forceAuthCodeOptions = {
+     returnUrl: "origin",
+     chsWebUrl: "accounts",
+     companyNumber: "12345678",
+     forceAuthCode: true
+    };
+    // @ts-ignore
+    const mockRequest = generateRequest({ ...instance(authedSession), data: {} })
+     when(authedSession.get<ISignInInfo>(SessionKey.SignInInfo)).thenReturn(generateSignInInfo(mockUserId, 1))
+    authMiddleware(forceAuthCodeOptions)(mockRequest, mockResponse, mockNext)
+    assert(redirectStub.calledOnceWith(expectedAuthReturnUrl))
+    assert(mockNext.notCalled)
+  })
+
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -118,61 +118,23 @@ describe('Authentication Middleware with company number', () => {
     assert(redirectStub.notCalled)
   })
 
-it("Should redirect with save_association=true and force_company_auth=true when forceCompanyAuth is true and saveAssociation is true", () => {
-    const mockForceCompanyAuthReturnUrl = 'accounts/signin?return_to=origin&company_number=12345678&force_company_auth=true&save_association=true'
+it("Should redirect with force-auth-code=true when forceAuthCode is true when the user is authenticated for company", () => {
+    const expectedAuthReturnUrl = 'accounts/signin?return_to=origin&company_number=12345678&force-auth-code=true'
 
-    const forceReauthOptions = {
+    const forceAuthCodeOptions = {
      returnUrl: "origin",
      chsWebUrl: "accounts",
      companyNumber: "12345678",
-     forceCompanyAuthentication: true,
-     saveAssociation: true
+     forceAuthCode: true
     };
     const authedSession = mock(Session);
     // @ts-ignore
     const mockRequest = generateRequest({...instance(authedSession), data: {} });
 
     when(authedSession.get<ISignInInfo>(SessionKey.SignInInfo)).thenReturn(generateSignInInfoAuthedForCompany(mockUserId, 1, "12345678"));
-    authMiddleware(forceReauthOptions)(mockRequest, mockResponse, mockNext);
-    assert(redirectStub.calledOnceWith(mockForceCompanyAuthReturnUrl));
+    authMiddleware(forceAuthCodeOptions)(mockRequest, mockResponse, mockNext);
+    assert(redirectStub.calledOnceWith(expectedAuthReturnUrl));
     assert(mockNext.notCalled);
   });
 
-it("When the user is authenticated for company, forceCompanyAuth=true and saveAssociation is missing the middleware should trigger redirect with correct url", () => {
-    
-    const mockForceCompanyAuthReturnUrl = 'accounts/signin?return_to=origin&company_number=12345678&force_company_auth=true&save_association=false'
-
-    const forceReauthOptionsWithoutSaveAssociation = {
-     returnUrl: "origin",
-     chsWebUrl: "accounts",
-     companyNumber: "12345678",
-     forceCompanyAuthentication: true,
-    };
-    const authedSession = mock(Session);
-    // @ts-ignore
-    const mockRequest = generateRequest({...instance(authedSession), data: {} });
-
-    when(authedSession.get<ISignInInfo>(SessionKey.SignInInfo)).thenReturn(generateSignInInfoAuthedForCompany(mockUserId, 1, "12345678"));
-    authMiddleware(forceReauthOptionsWithoutSaveAssociation)(mockRequest, mockResponse, mockNext);
-    assert(redirectStub.calledOnceWith(mockForceCompanyAuthReturnUrl));
-    assert(mockNext.notCalled);
-  });
-
-it("Should redirect with default company auth URL when forceCompanyAuth is false and user is not authenticated for company", () => {
-    
-    const forceReauthOptionsForceAuthIsFalse = {
-     returnUrl: "origin",
-     chsWebUrl: "accounts",
-     companyNumber: "12345678",
-     forceCompanyAuthentication: false,
-    };
-    const authedSession = mock(Session);
-    // @ts-ignore
-    const mockRequest = generateRequest({...instance(authedSession), data: {} });
-
-    when(authedSession.get<ISignInInfo>(SessionKey.SignInInfo)).thenReturn(generateSignInInfo(mockUserId, 1))
-    authMiddleware(forceReauthOptionsForceAuthIsFalse)(mockRequest, mockResponse, mockNext);
-    assert(redirectStub.calledOnceWith(mockReturnUrl));
-    assert(mockNext.notCalled);
-});
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,4 +117,21 @@ describe('Authentication Middleware with company number', () => {
     assert(mockNext.calledOnce)
     assert(redirectStub.notCalled)
   })
+
+  it("When the user is authenticated for company and forceCompanyAuth is true the middleware should not call next and should trigger redirect", () => {
+    const forceReauthOptions = {
+     returnUrl: "origin",
+     chsWebUrl: "accounts",
+     companyNumber: "12345678",
+     forceCompanyAuthentication: true,
+    };
+    const authedSession = mock(Session);
+    // @ts-ignore
+    const mockRequest = generateRequest({...instance(authedSession), data: {} });
+
+    when(authedSession.get<ISignInInfo>(SessionKey.SignInInfo)).thenReturn(generateSignInInfoAuthedForCompany(mockUserId, 1, "12345678"));
+    authMiddleware(forceReauthOptions)(mockRequest, mockResponse, mockNext);
+    assert(redirectStub.calledOnceWith(mockReturnUrl));
+    assert(mockNext.notCalled);
+  });
 })


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/SIV-279

**Description**
In some situations we want to force a user to re-authenticate for a company so they will always have to enter the company authentication code. This means even if they have previously authenticated and have the company number stored in their session they will still have to enter the company authentication code again.

- An additional option has been added to the AuthOptions interface - forceAuthCode?: boolean
- When forcing company authentication and redirecting to the company authentication screen, an additional query parameter  will be passed - force-auth-code=true when redirecting to the company login page.