### PR TITLE
Update error heading to match design system

### DIFF
--- a/components/csrf-error/macro.njk
+++ b/components/csrf-error/macro.njk
@@ -1,5 +1,5 @@
 {% macro csrfErrorContent() %}
-    <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
 
     <p class="govuk-body">We have not been able to save the information you submitted on the previous screen.
     This may be because the page was inactive for too long, or because of a technical issue.</p>


### PR DESCRIPTION
The GOV.UK Design System pattern on error handling uses a similar by different heading, should we align ours with the recommended pattern?

https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/